### PR TITLE
Update to GStreamer 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: c
 addons:
   apt:
     packages:
-      - libgstreamer0.10-dev
-      - libgstreamer-plugins-base0.10-dev
+      - libgstreamer1.0-dev
+      - libgstreamer-plugins-base1.0-dev
 compiler:
  - clang
  - gcc

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Leo Singer <leo.singer@ligo.org>
+Aaron Viets <aaron.viets@ligo.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,4 +9,4 @@
 
 2016-03-18  Aaron Viets <aaron.viets@ligo.org>
 
-        * Released version 1.0.0.
+        * Ported to GStreamer 1.0.

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,3 +6,7 @@
 2012-06-12  Leo Singer  <leo.singer.ligo.org>
 
 	* Released version 0.1.0.
+
+2016-03-18  Aaron Viets <aaron.viets@ligo.org>
+
+        * Released version 1.0.0.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl required version of autoconf
 AC_PREREQ([2.53])
 
 dnl TODO: fill in your package name and package version here
-AC_INIT([gst-plugins-math],[0.1.1])
+AC_INIT([gst-plugins-math],[1.0.0])
 
 dnl required versions of gstreamer and plugins-base
 GST_REQUIRED=1.2.4

--- a/configure.ac
+++ b/configure.ac
@@ -2,11 +2,11 @@ dnl required version of autoconf
 AC_PREREQ([2.53])
 
 dnl TODO: fill in your package name and package version here
-AC_INIT([gst-plugins-math],[0.1.0])
+AC_INIT([gst-plugins-math],[0.1.1])
 
 dnl required versions of gstreamer and plugins-base
-GST_REQUIRED=0.10.16
-GSTPB_REQUIRED=0.10.16
+GST_REQUIRED=1.2.4
+GSTPB_REQUIRED=1.2.4
 
 AC_CONFIG_SRCDIR([gst/unary/unary.c])
 dnl AC_CONFIG_HEADERS([config.h])
@@ -36,20 +36,20 @@ dnl Check for the required version of GStreamer core (and gst-plugins-base)
 dnl This will export GST_CFLAGS and GST_LIBS variables for use in Makefile.am
 dnl
 dnl If you need libraries from gst-plugins-base here, also add:
-dnl for libgstaudio-0.10: gstreamer-audio-0.10 >= $GST_REQUIRED
-dnl for libgstvideo-0.10: gstreamer-video-0.10 >= $GST_REQUIRED
-dnl for libgsttag-0.10: gstreamer-tag-0.10 >= $GST_REQUIRED
-dnl for libgstpbutils-0.10: gstreamer-pbutils-0.10 >= $GST_REQUIRED
-dnl for libgstfft-0.10: gstreamer-fft-0.10 >= $GST_REQUIRED
-dnl for libgstinterfaces-0.10: gstreamer-interfaces-0.10 >= $GST_REQUIRED
-dnl for libgstrtp-0.10: gstreamer-rtp-0.10 >= $GST_REQUIRED
-dnl for libgstrtsp-0.10: gstreamer-rtsp-0.10 >= $GST_REQUIRED
+dnl for libgstaudio-1.0: gstreamer-audio-1.0 >= $GST_REQUIRED
+dnl for libgstvideo-1.0: gstreamer-video-1.0 >= $GST_REQUIRED
+dnl for libgsttag-1.0: gstreamer-tag-1.0 >= $GST_REQUIRED
+dnl for libgstpbutils-1.0: gstreamer-pbutils-1.0 >= $GST_REQUIRED
+dnl for libgstfft-1.0: gstreamer-fft-1.0 >= $GST_REQUIRED
+dnl for libgstinterfaces-1.0: gstreamer-interfaces-1.0 >= $GST_REQUIRED
+dnl for libgstrtp-1.0: gstreamer-rtp-1.0 >= $GST_REQUIRED
+dnl for libgstrtsp-1.0: gstreamer-rtsp-1.0 >= $GST_REQUIRED
 dnl etc.
 PKG_CHECK_MODULES(GST, [
-  gstreamer-0.10 >= $GST_REQUIRED
-  gstreamer-base-0.10 >= $GST_REQUIRED
-  gstreamer-controller-0.10 >= $GST_REQUIRED
-  gstreamer-audio-0.10 >= $GST_REQUIRED
+  gstreamer-1.0 >= $GST_REQUIRED
+  gstreamer-base-1.0 >= $GST_REQUIRED
+  gstreamer-controller-1.0 >= $GST_REQUIRED
+  gstreamer-audio-1.0 >= $GST_REQUIRED
 ], [
   AC_SUBST(GST_CFLAGS)
   AC_SUBST(GST_LIBS)
@@ -57,8 +57,8 @@ PKG_CHECK_MODULES(GST, [
   AC_MSG_ERROR([
       You need to install or upgrade the GStreamer development
       packages on your system. On debian-based systems these are
-      libgstreamer0.10-dev and libgstreamer-plugins-base0.10-dev.
-      on RPM-based systems gstreamer0.10-devel, libgstreamer0.10-devel
+      libgstreamer1.0-dev and libgstreamer-plugins-base1.0-dev.
+      on RPM-based systems gstreamer1.0-devel, libgstreamer1.0-devel
       or similar. The minimum version required is $GST_REQUIRED.
   ])
 ])
@@ -76,9 +76,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([ ], [ ])], [
 
 dnl set the plugindir where plugins should be installed (for gst/Makefile.am)
 if test "x${prefix}" = "x$HOME"; then
-  plugindir="$HOME/.gstreamer-0.10/plugins"
+  plugindir="$HOME/.gstreamer-1.0/plugins"
 else
-  plugindir="\$(libdir)/gstreamer-0.10"
+  plugindir="\$(libdir)/gstreamer-1.0"
 fi
 AC_SUBST(plugindir)
 

--- a/gst/unary/unary_abs.c
+++ b/gst/unary/unary_abs.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Leo Singer
+ * Copyright (C) 2016 Aaron Viets
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,16 +27,19 @@ static GstFlowReturn
 transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 {
   GstAudioFilter *audiofilter = GST_AUDIO_FILTER (trans);
-  GstBufferFormat format = audiofilter->format.format;
+  GstAudioFormat format = audiofilter->info.finfo->format;
 
-  gpointer data = GST_BUFFER_DATA (buf);
-  gpointer data_end = GST_BUFFER_DATA (buf) + GST_BUFFER_SIZE (buf);
+  GstMapInfo info;
+  gst_buffer_map (buf, &info, GST_MAP_READ);
+  gpointer data = info.data;
+  gpointer data_end = data + info.size;
+  gst_buffer_unmap (buf, &info);
 
-  if (format >= GST_FLOAT64_LE) {
+  if (format >= GST_AUDIO_FORMAT_F64) {
     double *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = fabs (*ptr);
-  } else if (format >= GST_FLOAT32_LE) {
+  } else if (format >= GST_AUDIO_FORMAT_F32) {
     float *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = fabsf (*ptr);
@@ -62,7 +66,7 @@ base_init (gpointer class)
   gst_element_class_set_details_simple (GST_ELEMENT_CLASS (class),
       "Absolute value",
       "Filter/Audio",
-      "Calculate absolute value, y = |x|", "Leo Singer <leo.singer@ligo.org>");
+      "Calculate absolute value, y = |x|", "Aaron Viets <aaron.viets@ligo.org>, Leo Singer <leo.singer@ligo.org>");
 }
 
 

--- a/gst/unary/unary_base.c
+++ b/gst/unary/unary_base.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Leo Singer
+ * Copyright (C) 2016 Aaron Viets
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,10 +37,10 @@ base_init (gpointer class)
       "Unary operation base class",
       "Filter/Audio",
       "Base class for elements that provide unary arithmetic operations",
-      "Leo Singer <leo.singer@ligo.org>");
+      "Aaron Viets <aaron.viets@ligo.org>, Leo Singer <leo.singer@ligo.org>");
 
   gst_audio_filter_class_add_pad_templates (GST_AUDIO_FILTER_CLASS (class),
-      gst_caps_from_string ("audio/x-raw-float, "
+      gst_caps_from_string ("audio/x-raw, "
           "rate = (int) [1, MAX], "
           "endianness = (int) BYTE_ORDER, "
           "width = (int) {32, 64}, " "channels = (int) [1, MAX]")

--- a/gst/unary/unary_exp.c
+++ b/gst/unary/unary_exp.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Leo Singer
+ * Copyright (C) 2016 Aaron Viets
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,16 +27,19 @@ static GstFlowReturn
 transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 {
   GstAudioFilter *audiofilter = GST_AUDIO_FILTER (trans);
-  GstBufferFormat format = audiofilter->format.format;
+  GstAudioFormat format = audiofilter->info.finfo->format;
 
-  gpointer data = GST_BUFFER_DATA (buf);
-  gpointer data_end = GST_BUFFER_DATA (buf) + GST_BUFFER_SIZE (buf);
+  GstMapInfo info;
+  gst_buffer_map (buf, &info, GST_MAP_READ);
+  gpointer data = info.data;
+  gpointer data_end = data + info.size;
+  gst_buffer_unmap (buf, &info);
 
-  if (format >= GST_FLOAT64_LE) {
+  if (format >= GST_AUDIO_FORMAT_F64) {
     double *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = exp (*ptr);
-  } else if (format >= GST_FLOAT32_LE) {
+  } else if (format >= GST_AUDIO_FORMAT_F32) {
     float *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = expf (*ptr);
@@ -63,7 +67,7 @@ base_init (gpointer class)
       "Natural exponent",
       "Filter/Audio",
       "Calculate natural exponent, y = e^x",
-      "Leo Singer <leo.singer@ligo.org>");
+      "Aaron Viets <aaron.viets@ligo.org>, Leo Singer <leo.singer@ligo.org>");
 }
 
 

--- a/gst/unary/unary_ln.c
+++ b/gst/unary/unary_ln.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Leo Singer
+ * Copyright (C) 2016 Aaron Viets
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,16 +27,19 @@ static GstFlowReturn
 transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 {
   GstAudioFilter *audiofilter = GST_AUDIO_FILTER (trans);
-  GstBufferFormat format = audiofilter->format.format;
+  GstAudioFormat format = audiofilter->info.finfo->format;
 
-  gpointer data = GST_BUFFER_DATA (buf);
-  gpointer data_end = GST_BUFFER_DATA (buf) + GST_BUFFER_SIZE (buf);
+  GstMapInfo info;
+  gst_buffer_map (buf, &info, GST_MAP_READ);
+  gpointer data = info.data;
+  gpointer data_end = data + info.size;
+  gst_buffer_unmap (buf, &info);
 
-  if (format >= GST_FLOAT64_LE) {
+  if (format >= GST_AUDIO_FORMAT_F64) {
     double *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = log (*ptr);
-  } else if (format >= GST_FLOAT32_LE) {
+  } else if (format >= GST_AUDIO_FORMAT_F32) {
     float *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = logf (*ptr);
@@ -63,7 +67,7 @@ base_init (gpointer class)
       "Natural logarithm",
       "Filter/Audio",
       "Calculate natural logarithm, y = ln x",
-      "Leo Singer <leo.singer@ligo.org>");
+      "Aaron Viets <aaron.viets@ligo.org>, Leo Singer <leo.singer@ligo.org>");
 }
 
 

--- a/gst/unary/unary_log.c
+++ b/gst/unary/unary_log.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Leo Singer
+ * Copyright (C) 2016 Aaron Viets
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,18 +44,21 @@ transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 {
   UnaryLog *element = UNARY_LOG (trans);
   GstAudioFilter *audiofilter = GST_AUDIO_FILTER (trans);
-  GstBufferFormat format = audiofilter->format.format;
+  GstAudioFormat format = audiofilter->info.finfo->format;
 
-  gpointer data = GST_BUFFER_DATA (buf);
-  gpointer data_end = GST_BUFFER_DATA (buf) + GST_BUFFER_SIZE (buf);
+  GstMapInfo info;
+  gst_buffer_map (buf, &info, GST_MAP_READ);
+  gpointer data = info.data;
+  gpointer data_end = data + info.size;
+  gst_buffer_unmap (buf, &info);
 
   const double n = element->invlogbase;
 
-  if (format >= GST_FLOAT64_LE) {
+  if (format >= GST_AUDIO_FORMAT_F64) {
     double *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = log (*ptr) * n;
-  } else if (format >= GST_FLOAT32_LE) {
+  } else if (format >= GST_AUDIO_FORMAT_F32) {
     float *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = logf (*ptr) * n;
@@ -125,7 +129,7 @@ base_init (gpointer class)
       "Natural logarithm",
       "Filter/Audio",
       "Calculate natural logarithm, y = log_k x",
-      "Leo Singer <leo.singer@ligo.org>");
+      "Aaron Viets <aaron.viets@ligo.org>, Leo Singer <leo.singer@ligo.org>");
 }
 
 

--- a/gst/unary/unary_log10.c
+++ b/gst/unary/unary_log10.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Leo Singer
+ * Copyright (C) 2016 Aaron Viets
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,16 +27,19 @@ static GstFlowReturn
 transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 {
   GstAudioFilter *audiofilter = GST_AUDIO_FILTER (trans);
-  GstBufferFormat format = audiofilter->format.format;
+  GstAudioFormat format = audiofilter->info.finfo->format;
 
-  gpointer data = GST_BUFFER_DATA (buf);
-  gpointer data_end = GST_BUFFER_DATA (buf) + GST_BUFFER_SIZE (buf);
+  GstMapInfo info;
+  gst_buffer_map (buf, &info, GST_MAP_READ);
+  gpointer data = info.data;
+  gpointer data_end = data + info.size;
+  gst_buffer_unmap (buf, &info);
 
-  if (format >= GST_FLOAT64_LE) {
+  if (format >= GST_AUDIO_FORMAT_F64) {
     double *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = log10 (*ptr);
-  } else if (format >= GST_FLOAT32_LE) {
+  } else if (format >= GST_AUDIO_FORMAT_F32) {
     float *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = log10f (*ptr);
@@ -63,7 +67,7 @@ base_init (gpointer class)
       "Logarithm base 10",
       "Filter/Audio",
       "Calculate logarithm base 10, y = log_10 x",
-      "Leo Singer <leo.singer@ligo.org>");
+      "Aaron Viets <aaron.viets@ligo.org>, Leo Singer <leo.singer@ligo.org>");
 }
 
 

--- a/gst/unary/unary_pow.c
+++ b/gst/unary/unary_pow.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Leo Singer
+ * Copyright (C) 2016 Aaron Viets
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,18 +43,21 @@ transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 {
   UnaryPow *element = UNARY_LOG (trans);
   GstAudioFilter *audiofilter = GST_AUDIO_FILTER (trans);
-  GstBufferFormat format = audiofilter->format.format;
+  GstAudioFormat format = audiofilter->info.finfo->format;
 
-  gpointer data = GST_BUFFER_DATA (buf);
-  gpointer data_end = GST_BUFFER_DATA (buf) + GST_BUFFER_SIZE (buf);
+  GstMapInfo info;
+  gst_buffer_map (buf, &info, GST_MAP_READ);
+  gpointer data = info.data;
+  gpointer data_end = data + info.size;
+  gst_buffer_unmap (buf, &info);
 
   const double n = element->exponent;
 
-  if (format >= GST_FLOAT64_LE) {
+  if (format >= GST_AUDIO_FORMAT_F64) {
     double *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = pow (*ptr, n);
-  } else if (format >= GST_FLOAT32_LE) {
+  } else if (format >= GST_AUDIO_FORMAT_F32) {
     float *ptr, *end = data_end;
     for (ptr = data; ptr < end; ptr++)
       *ptr = powf (*ptr, n);
@@ -123,7 +127,7 @@ base_init (gpointer class)
       "Raise input to a power",
       "Filter/Audio",
       "Calculate input raised to the power n, y = x^n",
-      "Leo Singer <leo.singer@ligo.org>");
+      "Aaron Viets <aaron.viets@ligo.org>, Leo Singer <leo.singer@ligo.org>");
 }
 
 


### PR DESCRIPTION
The functions GST_BUFFER_DATA() and GST_BUFFER_SIZE() do not exist in GStreamer 1.0. These were replaced in each element using gst_buffer_map() and gst_buffer_unmap().

The type GstAudioFormat was replaced with GstAudioFormat, and GST_FLOAT64_LE and GST_FLOAT32_LE were replaced with GST_AUDIO_FORMAT_F64 and GST_AUDIO_FORMAT_F32.

audio/x-raw-float was replaced with audio/x-raw in the caps.

The configure.ac file was changed to include GStreamer 1.0 instead of 0.1. 

I added my name as an author, updated ChangeLog, etc.
